### PR TITLE
Fix relative backend path

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,12 +7,12 @@ RUN apk add --no-cache unzip ca-certificates
 
 USER app
 
-ADD https://github.com/pocketbase/pocketbase/releases/download/v${PB_VERSION}/pocketbase_${PB_VERSION}_linux_amd64.zip /tmp/pb.zip
+RUN wget -O /tmp/pb.zip https://github.com/pocketbase/pocketbase/releases/download/v${PB_VERSION}/pocketbase_${PB_VERSION}_linux_amd64.zip 
 
-RUN unzip /tmp/pb.zip -d /pb/
+RUN mkdir /home/app/pb && unzip /tmp/pb.zip -d /home/app/pb/
 
-COPY ./backend/pb_migrations /pb/pb_migrations
+COPY ./backend/pb_migrations /home/app/pb/pb_migrations
 
 EXPOSE 8080
 
-CMD ["/pb/pocketbase", "serve", "--http=0.0.0.0:8080"]
+CMD ["/home/app/pb/pocketbase", "serve", "--http=0.0.0.0:8080"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,23 +1,18 @@
 FROM alpine:3.19.1
-
-RUN addgroup -S nonroot \
-    && adduser -S nonroot -G nonroot
-
-USER nonroot
-
 ARG PB_VERSION=0.21.3
 
-RUN apk add --no-cache \
-    unzip \
-    ca-certificates
+RUN addgroup -S app && adduser -S -G app app
+
+RUN apk add --no-cache unzip ca-certificates
+
+USER app
 
 ADD https://github.com/pocketbase/pocketbase/releases/download/v${PB_VERSION}/pocketbase_${PB_VERSION}_linux_amd64.zip /tmp/pb.zip
+
 RUN unzip /tmp/pb.zip -d /pb/
 
 COPY ./backend/pb_migrations /pb/pb_migrations
-# COPY ./pb_hooks /pb/pb_hooks
 
 EXPOSE 8080
 
-# start PocketBase
 CMD ["/pb/pocketbase", "serve", "--http=0.0.0.0:8080"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,14 +11,10 @@ RUN apk add --no-cache \
     unzip \
     ca-certificates
 
-# download and unzip PocketBase
 ADD https://github.com/pocketbase/pocketbase/releases/download/v${PB_VERSION}/pocketbase_${PB_VERSION}_linux_amd64.zip /tmp/pb.zip
 RUN unzip /tmp/pb.zip -d /pb/
 
-# uncomment to copy the local pb_migrations dir into the image
-COPY ./pb_migrations /pb/pb_migrations
-
-# uncomment to copy the local pb_hooks dir into the image
+COPY ./backend/pb_migrations /pb/pb_migrations
 # COPY ./pb_hooks /pb/pb_hooks
 
 EXPOSE 8080


### PR DESCRIPTION
This pull request fixes the issue with the relative backend path by updating the COPY command in the Dockerfile to copy the pb_migrations directory from the backend folder.